### PR TITLE
chore: enforce LF with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Normalize text files
+* text=auto
+
+# Force LF for scripts and CI
+*.sh   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+Dockerfile text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
-on:
-  push:
-  pull_request:
+on: { push: {}, pull_request: {} }
 jobs:
   rn:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoid CRLF/LF warnings on Windows in CI and scripts.